### PR TITLE
prevents jobs from running after deletion. fixes remove_job function

### DIFF
--- a/lib/tide-scheduler.js
+++ b/lib/tide-scheduler.js
@@ -39,20 +39,24 @@ module.exports = {
             this.core.applications.add(config.application);
 
             this.jobs[config.id].schedule(function(){
-                async.timesSeries(config.instances, function(index, fn){
-                    self.core.applications.deploy_container(config.application.id, {}, function(){
-                        self.core.loggers["tide-scheduler"].log("verbose", ["Launched instance for job:", config.id].join(" "));
-                        return fn();
+                if(_.has(self.core.applications.list, config.application.id)){
+                    async.timesSeries(config.instances, function(index, fn){
+                        self.core.applications.deploy_container(config.application.id, {}, function(){
+                            self.core.loggers["tide-scheduler"].log("verbose", ["Launched instance for job:", config.id].join(" "));
+                            return fn();
+                        });
+                    }, function(){
+                        var interval = setInterval(function(){
+                            if(self.core.applications.list[config.application.id].serialize().containers.length == 0){
+                                clearInterval(interval);
+                                if(!config.schedule.recurring)
+                                    self.remove_job(config, function(){});
+                            }
+                        }, 15000);
                     });
-                }, function(){
-                    var interval = setInterval(function(){
-                        if(self.core.applications.list[config.application.id].serialize().containers.length == 0){
-                            clearInterval(interval);
-                            if(!config.schedule.recurring)
-                                self.remove_job(config.id, function(){});
-                        }
-                    }, 15000);
-                });
+                }
+                else
+                    self.remove_job(config);
             });
         }
 
@@ -77,15 +81,16 @@ module.exports = {
     },
 
     remove_job: function(id, fn){
-        this.core.loggers["tide-scheduler"].log("verbose", ["Removed job:", id].join(" "));
+        this.core.loggers["tide-scheduler"].log("verbose", ["Removed job:", config.id].join(" "));
 
         if(this.core.cluster.praetor.is_controlling_leader()){
-            this.jobs[id].cancel();
-            this.core.cluster.legiond.send("tide.job.remove", id);
+            this.jobs[config.id].cancel();
+            this.core.cluster.legiond.send("tide.job.remove", config.id);
         }
 
-        delete this.jobs[id];
-        this.persist(fn);
+        this.core.applications.remove(config.application.id);
+        delete this.jobs[config.id];
+        this.persist_jobs(fn);
     }
 
 }

--- a/lib/tide-scheduler.js
+++ b/lib/tide-scheduler.js
@@ -50,13 +50,13 @@ module.exports = {
                             if(self.core.applications.list[config.application.id].serialize().containers.length == 0){
                                 clearInterval(interval);
                                 if(!config.schedule.recurring)
-                                    self.remove_job(config, function(){});
+                                    self.remove_job(config.id, function(){});
                             }
                         }, 15000);
                     });
                 }
                 else
-                    self.remove_job(config);
+                    self.remove_job(config.id);
             });
         }
 
@@ -81,15 +81,15 @@ module.exports = {
     },
 
     remove_job: function(id, fn){
-        this.core.loggers["tide-scheduler"].log("verbose", ["Removed job:", config.id].join(" "));
+        this.core.loggers["tide-scheduler"].log("verbose", ["Removed job:", id].join(" "));
 
         if(this.core.cluster.praetor.is_controlling_leader()){
-            this.jobs[config.id].cancel();
-            this.core.cluster.legiond.send("tide.job.remove", config.id);
+            this.jobs[id].cancel();
+            this.core.cluster.legiond.send("tide.job.remove", id);
         }
 
-        this.core.applications.remove(config.application.id);
-        delete this.jobs[config.id];
+        this.core.applications.remove(["tide", id].join("."));
+        delete this.jobs[id];
         this.persist_jobs(fn);
     }
 


### PR DESCRIPTION
fixes `remove_job` function by ensuring application is removed from ContainerShip, and is also removed from the `tide.json` snapshot. ensures application still exists before attempting to schedule containers to run